### PR TITLE
update bump-and-branch doc to use devel and 3.17 references

### DIFF
--- a/vignettes/Version-bump-and-branch-creation-HOWTO.Rmd
+++ b/vignettes/Version-bump-and-branch-creation-HOWTO.Rmd
@@ -20,15 +20,15 @@ On the day prior to the release, we will need to apply and push the following
 changes to all the Bioconductor packages that go in the release, **in this
 order**:
 
-- **First version bump**: bump x.y.z version to even y **in the `master`
+- **First version bump**: bump x.y.z version to even y **in the `devel`
   branch**
 - **Branch creation**: create the release branch
-- **Second version bump**: bump x.y.z version to odd y **in the `master`
+- **Second version bump**: bump x.y.z version to odd y **in the `devel`
   branch**
 
-For example, for the BioC 3.16 release, we will need to do this for all
+For example, for the BioC 3.17 release, we will need to do this for all
 the packages listed in the `software.txt`, `data-experiment.txt`,
-`workflows.txt`, and `books.txt` files of the `RELEASE_3_16` branch
+`workflows.txt`, and `books.txt` files of the `RELEASE_3_17` branch
 of the `manifest` repo.
 
 Note that there are some exceptions:
@@ -41,11 +41,11 @@ Note that there are some exceptions:
 
 We'll use Python script `bump_version_and_create_branch.py` to apply and
 push these changes. This will need to be done on the day prior to the release
-before the BioC 3.16 builds start for software, data-experiment, workflow, and
+before the BioC 3.17 builds start for software, data-experiment, workflow, and
 book packages.
 
 Look for the prerun jobs in the crontab for the `biocbuild` user on the central
-BioC 3.16 builder to get the times the software and data-experiment builds get
+BioC 3.17 builder to get the times the software and data-experiment builds get
 kicked off. Make sure to check the crontab again a couple of days before the
 release as we sometimes make small adjustments to the crontabs on the build
 machines.  Also be sure to translate to your local time if you are not on the
@@ -58,7 +58,7 @@ These steps should be performed typically a couple of days before the steps
 in sections **C.** and **D.**.
 
 * Update this document to reflect the BioC version to be released i.e.
-  replace all occurrences of `3.16` and `RELEASE_3_16` with appropriate
+  replace all occurrences of `3.17` and `RELEASE_3_17` with appropriate
   version. This will avoid potentially disastrous mistakes when
   copying/pasting/executing commands from this document.
 
@@ -107,22 +107,22 @@ in sections **C.** and **D.**.
   export BBS_HOME="$HOME/BBS"
   
   # clone `manifest` repo
-  $BBS_HOME/utils/update_bioc_git_repos.py manifest RELEASE_3_16
+  $BBS_HOME/utils/update_bioc_git_repos.py manifest RELEASE_3_17
   
   # clone software package repos (takes approx. 1h20)
-  time $BBS_HOME/utils/update_bioc_git_repos.py software master RELEASE_3_16
+  time $BBS_HOME/utils/update_bioc_git_repos.py software devel RELEASE_3_17
   
   # clone data-annotation package repos (takes a couple of minutes)
-  time $BBS_HOME/utils/update_bioc_git_repos.py data-annotation master RELEASE_3_16
+  time $BBS_HOME/utils/update_bioc_git_repos.py data-annotation devel RELEASE_3_17
   
   # clone data-experiment package repos (takes approx. 1h50)
-  time $BBS_HOME/utils/update_bioc_git_repos.py data-experiment master RELEASE_3_16
+  time $BBS_HOME/utils/update_bioc_git_repos.py data-experiment devel RELEASE_3_17
   
   # clone workflow package repos (takes approx. 4 min)
-  time $BBS_HOME/utils/update_bioc_git_repos.py workflows master RELEASE_3_16
+  time $BBS_HOME/utils/update_bioc_git_repos.py workflows devel RELEASE_3_17
   
   # clone book repos (takes < 1 min)
-  time $BBS_HOME/utils/update_bioc_git_repos.py books master RELEASE_3_16
+  time $BBS_HOME/utils/update_bioc_git_repos.py books devel RELEASE_3_17
   ```
 
 * Make sure you can push changes to the BioC git server (at
@@ -198,14 +198,14 @@ Perform these steps on the day prior to the release. They must be completed
 before the software builds get kicked off (see **A. Introduction**). The full
 procedure should take about 3 hours. Make sure to reserve enough time.
 
-### C1. Comment out all builds in crontab on central BioC 3.16 builder
+### C1. Comment out all builds in crontab on central BioC 3.17 builder
 
-No 3.16 build should start until:
+No 3.17 build should start until:
 
 - the bump and branch process is complete,
 
-- **and** `BBS_BIOC_GIT_BRANCH` is switched from `master` to `RELEASE_3_16`
-  on the central BioC 3.16 builder (this switch is documented in section
+- **and** `BBS_BIOC_GIT_BRANCH` is switched from `devel` to `RELEASE_3_17`
+  on the central BioC 3.17 builder (this switch is documented in section
   F3 below).
 
 Maybe no build is scheduled to start during the next 3 hours, in which case
@@ -220,23 +220,23 @@ list that people must stop committing/pushing changes to the BioC git server
 
 ### C3. Modify packages.conf to block all commits
 
-The `RELEASE_3_15` lines in `gitolite-admin/conf/packages.conf` were commented
-out when the release builds were frozen. At this point, only the `master`
+The `RELEASE_3_16` lines in `gitolite-admin/conf/packages.conf` were commented
+out when the release builds were frozen. At this point, only the `devel`
 lines are still active.
 
-Deactivate all push access by commenting out the `master` lines in
+Deactivate all push access by commenting out the `devel` lines in
 `gitolite-admin/conf/packages.conf`.
 
-NOTE: Do not change the branch from RELEASE_3_15 to RELEASE_3_16, it is
+NOTE: Do not change the branch from RELEASE_3_16 to RELEASE_3_17, it is
 not a good solution. Maintainers now will be able to push their own
-RELEASE_3_16 branch before we are able to create it at release
+RELEASE_3_17 branch before we are able to create it at release
 time. This issue reflects the issue
 <https://stat.ethz.ch/pipermail/bioc-devel/2019-May/015048.html>.
 
 Using vim, it is possible with a one liner:
 
 ```vi
-:g/RW master/s/^/#
+:g/RW devel/s/^/#
 ```
 
 Or Lori created `sed` commands see `scripts/sedCommandsForVariousTasks.txt`
@@ -258,7 +258,7 @@ Log on to git.bioconductor.org as the `git` user.
   rm -rf ~/repositories/packages/*.git/hooks/pre-receive.h00-pre-receive-hook-software
   ```
 
-Or (trying as of release 3.16) try using hooks exclusion file. See
+Or (trying as of release 3.17) try using hooks exclusion file. See
 scripts/sedCommandsForVariousTasks.txt. This changes is made in the
 hook_maintainer repo. 
 
@@ -274,12 +274,12 @@ ssh -A hpages@malbec1.bioconductor.org
 
 See **B. Preliminary steps** above for the details.
 
-### C6. Checkout/update the `RELEASE_3_16` branch of the `manifest` repo
+### C6. Checkout/update the `RELEASE_3_17` branch of the `manifest` repo
 
 ```sh
 cd ~/git.bioconductor.org/manifest
 git pull --all
-git checkout RELEASE_3_16
+git checkout RELEASE_3_17
 git branch
 git status
 ```
@@ -311,7 +311,7 @@ workflows, and books.
   ```
 
 - `MANIFEST_FILE`: Point `MANIFEST_FILE` to the manifest file for software
-  packages. This must be the file from the `RELEASE_3_16` branch of
+  packages. This must be the file from the `RELEASE_3_17` branch of
   the `manifest` repo:
   
   ```sh
@@ -327,7 +327,7 @@ of applying and pushing the changes described in **A. Introduction**.
 cd $WORKING_DIR
 pkgs_in_manifest=`grep 'Package: ' $MANIFEST_FILE | sed 's/Package: //g'`
 
-$BBS_HOME/utils/bump_version_and_create_branch.py --push RELEASE_3_16 $pkgs_in_manifest >bump_version_and_create_branch.log 2>&1 &
+$BBS_HOME/utils/bump_version_and_create_branch.py --push RELEASE_3_17 $pkgs_in_manifest >bump_version_and_create_branch.log 2>&1 &
 ```
 
 The `bump_version_and_create_branch.py` run above can be replaced with
@@ -335,9 +335,9 @@ a 2-pass run:
 
 ```sh
 # First pass (apply all the changes but do NOT push them):
-$BBS_HOME/utils/bump_version_and_create_branch.py RELEASE_3_16 $pkgs_in_manifest >bump_version_and_create_branch.log1 2>&1 &
+$BBS_HOME/utils/bump_version_and_create_branch.py RELEASE_3_17 $pkgs_in_manifest >bump_version_and_create_branch.log1 2>&1 &
 # Second pass (push all the changes):
-$BBS_HOME/utils/bump_version_and_create_branch.py --push RELEASE_3_16 $pkgs_in_manifest >bump_version_and_create_branch.log2 2>&1 &
+$BBS_HOME/utils/bump_version_and_create_branch.py --push RELEASE_3_17 $pkgs_in_manifest >bump_version_and_create_branch.log2 2>&1 &
 ```
 
 The 2-pass run can be useful if one wants to inspect the changes before pushing them.
@@ -350,7 +350,7 @@ Notes:
 
 * In the 2-pass run, the second pass checks the packages and applies the
   changes only if needed (i.e. if a package does not already have the
-  `RELEASE_3_16` branch) before pushing the changes.
+  `RELEASE_3_17` branch) before pushing the changes.
 
 * If for some reason the `bump_version_and_create_branch.py` script stops
   prematurly, it can be safely re-run with the same arguments. This is
@@ -421,21 +421,21 @@ script with the `--no-bump` option**:
 cd $WORKING_DIR
 pkgs_in_manifest=`grep 'Package: ' $MANIFEST_FILE | sed 's/Package: //g'`
 
-$BBS_HOME/utils/bump_version_and_create_branch.py --no-bump --push RELEASE_3_16 $pkgs_in_manifest >bump_version_and_create_branch.log 2>&1 &
+$BBS_HOME/utils/bump_version_and_create_branch.py --no-bump --push RELEASE_3_17 $pkgs_in_manifest >bump_version_and_create_branch.log 2>&1 &
 ```
 
 
 ## F. Finishing up
 
-### F1. Enable push access to new `RELEASE_3_16` branch
+### F1. Enable push access to new `RELEASE_3_17` branch
 
 This is done by editing the `conf/packages.conf` file in the `gitolite-admin`
 repo (`git clone git@git.bioconductor.org:gitolite-admin`).
 
-- If not done already, replace all instances of `RELEASE_3_15` with
-  `RELEASE_3_16`.
+- If not done already, replace all instances of `RELEASE_3_16` with
+  `RELEASE_3_17`.
 
-- Uncomment all `RELEASE_3_16` and `master` lines.
+- Uncomment all `RELEASE_3_17` and `devel` lines.
 
 See scripts/sedCommandsForVariousTasks.txt for help on re-enabling access
 
@@ -451,7 +451,7 @@ See scripts/sedCommandsForVariousTasks.txt for help on re-enabling access
 
   ```sh
   git push
-  git checkout RELEASE_3_16
+  git checkout RELEASE_3_17
   git pull
   ```
 
@@ -461,42 +461,42 @@ Announce or ask a core team member to announce on the bioc-devel mailing list
 that committing/pushing changes to the BioC git server (git.bioconductor.org)
 can resume.
 
-### F3. Switch `BBS_BIOC_GIT_BRANCH` from `master` to `RELEASE_3_16` on central BioC 3.16 builder
+### F3. Switch `BBS_BIOC_GIT_BRANCH` from `devel` to `RELEASE_3_17` on central BioC 3.17 builder
 
-DON'T FORGET THIS STEP! Its purpose is to make the BioC 3.16 builds grab the
-`RELEASE_3_16` branch of all packages instead of their `master` branch.
+DON'T FORGET THIS STEP! Its purpose is to make the BioC 3.17 builds grab the
+`RELEASE_3_17` branch of all packages instead of their `devel` branch.
 
-Login to the central BioC 3.16 builder as `biocbuild` and replace
+Login to the central BioC 3.17 builder as `biocbuild` and replace
 
 ```sh
-export BBS_BIOC_GIT_BRANCH="master"
+export BBS_BIOC_GIT_BRANCH="devel"
 ```
 
 with
 
 ```sh
-export BBS_BIOC_GIT_BRANCH="RELEASE_3_16"
+export BBS_BIOC_GIT_BRANCH="RELEASE_3_17"
 ```
 
-in `~/BBS/3.16/config.sh`
+in `~/BBS/3.17/config.sh`
 
 Also replace
 
 ```sh
-set BBS_BIOC_GIT_BRANCH=master
+set BBS_BIOC_GIT_BRANCH=devel
 ```
 
 with
 
 ```sh
-set BBS_BIOC_GIT_BRANCH=RELEASE_3_16
+set BBS_BIOC_GIT_BRANCH=RELEASE_3_17
 ```
 
-in `~/BBS/3.16/config.bat`
+in `~/BBS/3.17/config.bat`
 
-Then remove the `manifest` and `MEAT0` folders from `~/bbs-3.16-bioc/`,
-`~/bbs-3.16-data-annotation/`, `~/bbs-3.16-data-experiment/`,
-`~/bbs-3.16-workflows/`, and `~/bbs-3.16-books/`. They'll get automatically
+Then remove the `manifest` and `MEAT0` folders from `~/bbs-3.17-bioc/`,
+`~/bbs-3.17-data-annotation/`, `~/bbs-3.17-data-experiment/`,
+`~/bbs-3.17-workflows/`, and `~/bbs-3.17-books/`. They'll get automatically
 re-created and re-populated when the builds start.
 
 Once you're done, don't forget to uncomment all the builds that were
@@ -525,7 +525,7 @@ work if the user has admin access to the organization's GitHub account.
 To update all packages, run the following command:
 
 ```r
-add_gh_release_branches(release = "RELEASE_3_16", org = "Bioconductor")
+add_gh_release_branches(release = "RELEASE_3_17", org = "Bioconductor")
 ```
 
 Be sure to edit the `release` argument in the function.
@@ -534,7 +534,7 @@ To update an individual package, run the following function:
 
 ```r
 add_gh_release_branch(
-    package_name = "updateObject", release = "RELEASE_3_16", gh_branch = "master"
+    package_name = "updateObject", release = "RELEASE_3_17", gh_branch = "devel"
 )
 ```
 


### PR DESCRIPTION
I've updated the documentation in `Version-bump-and-branch-creation-HOWTO.Rmd` to use `devel` as the default. 
I did _not_ modify the scripts are used for release tasks. 
cc: @lshep 