### PR TITLE
Spell out docker and binaries tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -318,7 +318,7 @@ Website updates:
 
 - [ ] Branch Annotations and put backup into S3 bucket
 
-- [ ]  Build dockers for new release
+- [ ] Build dockers for new release
 
 - [ ] Build container binaries for new release
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -336,11 +336,11 @@ Website updates:
 
 - [ ] Build bioc2u binaries for new release
 
-- [ ] Build bioc2u binaries for new devel
+- [ ] Build bioc2u binaries for new devel (only for Spring release when R release is used for Bioc devel)
 
 - [ ] Build webr binaries for new release
 
-- [ ] Build webr binaries for new devel
+- [ ] Build webr binaries for new devel (only for Spring release when R release is used for Bioc devel)
 
 - [ ] Update SPB and clean sqlite file
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -318,7 +318,21 @@ Website updates:
 
 - [ ] Branch Annotations and put backup into S3 bucket
 
-- [ ] Build dockers for new release and devel for Bioc and AnVIL
+- [ ]  Build dockers for new release
+
+- [ ] Build container binaries for new release
+
+- [ ] Build dockers for new devel
+
+- [ ] Build container binaries for new devel
+
+- [ ] Build bioc2u binaries for new release
+
+- [ ] Build bioc2u binaries for new devel
+
+- [ ] Build webr binaries for new release
+
+- [ ] Build webr binaries for new devel
 
 - [ ] Update SPB and clean sqlite file
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -318,13 +318,21 @@ Website updates:
 
 - [ ] Branch Annotations and put backup into S3 bucket
 
-- [ ] Build dockers for new release
+- [ ] Build dockers for new release (bioconductor_docker)
 
-- [ ] Build container binaries for new release
+- [ ] Build container binaries for new release (bioconductor_docker)
 
-- [ ] Build dockers for new devel
+- [ ] Build dockers for new devel (bioconductor_docker)
 
-- [ ] Build container binaries for new devel
+- [ ] Build container binaries for new devel (bioconductor_docker)
+
+- [ ] Build dockers for new release (AnVIL)
+
+- [ ] Build container binaries for new release (AnVIL)
+
+- [ ] Build dockers for new devel (AnVIL)
+
+- [ ] Build container binaries for new devel (AnVIL)
 
 - [ ] Build bioc2u binaries for new release
 

--- a/vignettes/ReleaseChecklist.Rmd
+++ b/vignettes/ReleaseChecklist.Rmd
@@ -363,13 +363,21 @@ It couldn't hurt to restart the Apache server:
   numbered y of x.y.z version left over from being devel and highlight packages
   that are erroring in release.  
 
-- Build dockers for new release
+- Build dockers for new release (bioconductor_docker)
 
-- Build container binaries for new release
+- Build container binaries for new release (bioconductor_docker)
 
-- Build dockers for new devel
+- Build dockers for new devel (bioconductor_docker)
 
-- Build container binaries for new devel
+- Build container binaries for new devel (bioconductor_docker)
+
+- Build dockers for new release (AnVIL)
+
+- Build container binaries for new release (AnVIL)
+
+- Build dockers for new devel (AnVIL)
+
+- Build container binaries for new devel (AnVIL)
 
 - Build bioc2u binaries for new release
 

--- a/vignettes/ReleaseChecklist.Rmd
+++ b/vignettes/ReleaseChecklist.Rmd
@@ -363,7 +363,21 @@ It couldn't hurt to restart the Apache server:
   numbered y of x.y.z version left over from being devel and highlight packages
   that are erroring in release.  
 
-- Build dockers for new release and devel
+- Build dockers for new release
+
+- Build container binaries for new release
+
+- Build dockers for new devel
+
+- Build container binaries for new devel
+
+- Build bioc2u binaries for new release
+
+- Build bioc2u binaries for new devel
+
+- Build webr binaries for new release
+
+- Build webr binaries for new devel
 
 - Update SPB and clean sqlite file
 


### PR DESCRIPTION
Separating docker builds and adding binary builds for more granularity on post-release tasks